### PR TITLE
fix broken smcalflow link

### DIFF
--- a/datasets/smcalflow.sh
+++ b/datasets/smcalflow.sh
@@ -1,2 +1,2 @@
-wget -P ./smcalflow https://github.com/microsoft/task_oriented_dialogue_as_dataflow_synthesis/blob/master/datasets/SMCalFlow%202.0/train.dataflow_dialogues.jsonl.zip
+wget -P ./smcalflow https://github.com/microsoft/task_oriented_dialogue_as_dataflow_synthesis/raw/master/datasets/SMCalFlow%202.0/train.dataflow_dialogues.jsonl.zip
 unzip ./smcalflow/train.dataflow_dialogues.jsonl.zip -d ./smcalflow


### PR DESCRIPTION
blob version of github websites is written in html.
To download datasets, you can use the raw version