### PR TITLE
Upgrade sklearn to appropriate version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ xlrd==1.2.0
 parlai
 git+https://github.com/Maluuba/nlg-eval.git@master
 tensorflow==2.6.2
-scikit-learn==0.21.3
+scikit-learn==1.0.2
 rouge_score
 wandb
 py7zr


### PR DESCRIPTION
sklearn version 0.21.3 doesn't utilize the "zero_division" parameter for classification metrics, which is called in lines 263, 265, and 269 in Instructdial/scripts/run_eval.py. Due to this mismatch, run_eval.py throws as error and won't run.

To fix this issue, I ran pip install --upgrade scikit-learn which determined that version 1.0.2 satisfied all existing version requirements, and utilizes the "zero_division" parameter when calculating classification metrics.